### PR TITLE
Update git-at-scale link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 
         <p class="c-paragraph-3">GVFS also manages Git's internal state so that it only considers the files you have accessed, instead of having to examine every file in the repository. This ensures that operations like status and checkout are as fast as possible.</p>
 
-        <p class="c-paragraph-3"><a href="https://visualstudio.com/git-at-scale/" class="c-call-to-action c-glyph f-lightweight">LEARN MORE</a></p>
+        <p class="c-paragraph-3"><a href="https://visualstudio.com/learn/git-at-scale/" class="c-call-to-action c-glyph f-lightweight">LEARN MORE</a></p>
 
       </div>
     </div>


### PR DESCRIPTION
As reported in https://github.com/Microsoft/GVFS/issues/74, the git-at-scale link is broken.