### PR TITLE
Replace references to VSTS with Azure DevOps Services

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>GVFS: Git at Enterprise Scale</title>
-  
+
   <link rel='stylesheet prefetch' href='https://assets.onestore.ms/cdnfiles/external/mwf/short/v1/latest/css/mwf-west-european-default.min.css'>
   <link rel="stylesheet" href="css/style.css">
 </head>
@@ -82,23 +82,23 @@
       <h2 class="c-heading-3 f-lean">Why GVFS?</h2>
       <p class="c-paragraph-3">Git struggles to handle enterprise-scale repositories. Operations like cloning will slow to a crawl when you have millions of files in a repository, and even something as simple as getting your repository status will leave you waiting.</p>
 
-      <p class="c-paragraph-3">GVFS was created by the <a href="https://www.visualstudio.com/team-services/" class="c-hyperlink">Visual Studio Team Services</a> team at Microsoft, specifically to deal with these scale issues for Microsoft's own codebases.</p>
+      <p class="c-paragraph-3">GVFS was created by the <a href="https://www.visualstudio.com/team-services/" class="c-hyperlink">Azure DevOps Services</a> team at Microsoft, specifically to deal with these scale issues for Microsoft's own codebases.</p>
 
-      <p class="c-paragraph-3">With GVFS, developers using Git and Visual Studio Team Services can stay productive, even in mammoth repositories like the Windows operating system, which clocks in at roughly 300 GB (3.5 million files). It's the <a href="https://blogs.msdn.microsoft.com/bharry/2017/05/24/the-largest-git-repo-on-the-planet/"
+      <p class="c-paragraph-3">With GVFS, developers using Git and Azure DevOps Services can stay productive, even in mammoth repositories like the Windows operating system, which clocks in at roughly 300 GB (3.5 million files). It's the <a href="https://blogs.msdn.microsoft.com/bharry/2017/05/24/the-largest-git-repo-on-the-planet/"
           class="c-hyperlink">largest Git repository in the world</a>.</p>
 
       <p class="c-paragraph-3">GVFS is freely available and Open Source. If your team and your codebase are growing to enterprise-scale, GVFS may be a great fit.</p>
     </div>
     <div data-grid="col-6" class="m-content-placement-item f-size-large">
       <picture>
-        <img src="images/why-gvfs.png" alt="Three-up display of logos with Windows, Git, and Visual Studio Team Services">
+        <img src="images/why-gvfs.png" alt="Three-up display of logos with Windows, Git, and Azure DevOps Services">
       </picture>
     </div>
   </div>
 
   <div data-grid="col-12" class="m-content-placement">
     <h2 class="c-heading-3">Example: GVFS and the Windows repository</h2>
-    <p class="c-paragraph-3">Here's a comparison of some common Git actions on the Windows repository with Visual Studio Team Services.</p>
+    <p class="c-paragraph-3">Here's a comparison of some common Git actions on the Windows repository with Azure DevOps Services.</p>
     <div class="c-table">
       <table>
         <thead>
@@ -155,7 +155,7 @@
     </div>
   </div>
 
-  <div data-grid="container"> 
+  <div data-grid="container">
     <div data-grid="col-12" class="m-content-placement">
         <h2 class="c-heading-3">GVFS in the news</h2>
         <div class="c-content-toggle">
@@ -177,7 +177,7 @@
         <h2 class="c-heading-3">Trusted by:</h2>
       </div>
       <div data-grid="col-12" class="m-banner">
-          <a href="https://www.visualstudio.com/team-services/"><img src="images/logo-vsts.png" height="48px" alt="Visual Studio Team Services logo" /></a>
+          <a href="https://www.visualstudio.com/team-services/"><img src="images/logo-vsts.png" height="48px" alt="Azure DevOps Services logo" /></a>
           <a href="https://www.visualstudio.com/vs/"><img src="images/logo-visualstudio.png" height="48px" alt="Visual Studio logo" /></a>
       </div>
       <div data-grid="col-12" class="m-banner">
@@ -211,7 +211,7 @@
 
   <div id="gvfs-footer" data-grid="container">
     <div data-grid="col-12" class="m-content-placement">
-    <p class="c-paragraph-3">GVFS was created by the <a href="https://www.visualstudio.com/team-services/" class="c-hyperlink">Visual Studio Team Services</a> team and is Open Source with &hearts; from <a href="https://www.microsoft.com/" class="c-hyperlink"><strong>Microsoft</strong></a>.</p>
+    <p class="c-paragraph-3">GVFS was created by the <a href="https://www.visualstudio.com/team-services/" class="c-hyperlink">Azure DevOps Services</a> team and is Open Source with &hearts; from <a href="https://www.microsoft.com/" class="c-hyperlink"><strong>Microsoft</strong></a>.</p>
     </div>
   </div>
 </main>
@@ -227,6 +227,6 @@
 
 <!-- JavaScript additions -->
 <!-- ... -->
-    
+
 </body>
 </html>


### PR DESCRIPTION
See Issue #11.  This PR updates the naming from the old Visual Studio Team services to Azure DevOps Services.