### PR TITLE
Renamed www.gvfs.io to www.vfsforgit.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.gvfs.io
+www.vfsforgit.org

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GVFS.WWW 
 
-This is the [web site for GVFS](http:// www.vfsforgit.org ), the technology
+This is the [web site for GVFS](www.vfsforgit.org ), the technology
 that powers Git to handle repositories at Microsoft scale.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GVFS.WWW 
 
-This is the [web site for GVFS](http://www.gvfs.io/), the technology
+This is the [web site for GVFS](http:// www.vfsforgit.org ), the technology
 that powers Git to handle repositories at Microsoft scale.
 
 ## Contributing


### PR DESCRIPTION
This PR is regarding rename of www.gvfs.io to www.vfsforgit.org
This closes #15 